### PR TITLE
Bugfix handle of sys.exit() and return code (Imporant for CI usage)

### DIFF
--- a/dev-shell.py
+++ b/dev-shell.py
@@ -48,18 +48,10 @@ POETRY_PATH = BIN_PATH / f'poetry{FILE_EXT}'
 PROJECT_SHELL_SCRIPT = BIN_PATH / 'devshell'
 
 
-def _subprocess(subprocess_func, popenargs):
+def verbose_check_call(*popenargs):
     popenargs = [str(arg) for arg in popenargs]  # e.g.: Path() -> str for python 3.7
     print(f'\n\n+ {" ".join(popenargs)}\n')
-    subprocess_func(popenargs)
-
-
-def verbose_check_call(*popenargs):
-    _subprocess(subprocess.check_call, popenargs)
-
-
-def verbose_call(*popenargs):
-    _subprocess(subprocess.call, popenargs)
+    return subprocess.check_call(popenargs)
 
 
 def noop_signal_handler(signal_num, frame):
@@ -116,4 +108,7 @@ if __name__ == '__main__':
 
     # Run project cmd shell via "setup.py" entrypoint:
     # (Call it via python, because Windows sucks calling the file direct)
-    verbose_call(PYTHON_PATH, PROJECT_SHELL_SCRIPT, *extra_args)
+    try:
+        verbose_check_call(PYTHON_PATH, PROJECT_SHELL_SCRIPT, *extra_args)
+    except subprocess.CalledProcessError as err:
+        sys.exit(err.returncode)

--- a/dev_shell/base_cmd2_app.py
+++ b/dev_shell/base_cmd2_app.py
@@ -48,15 +48,24 @@ class DevShellBaseApp(cmd2.Cmd):
 
         self.update_path()
 
-    def onecmd_plus_hooks(self, *args, **kwargs):
+    def onecmd(self, *args, **kwargs):
         """
-        Exit cmdloop if shell was used as CLI ;)
+        1. Exit cmdloop if shell was used as CLI ;)
+        2. Pass sys.exit() code
         """
-        stop = super().onecmd_plus_hooks(*args, **kwargs)
+        try:
+            stop = super().onecmd(*args, **kwargs)
+        except SystemExit as exit_code:
+            # Pass the sys.exit() code
+            # See also: https://github.com/python-cmd2/cmd2/pull/1076
+            self.exit_code = exit_code
+            stop = False
+
         if len(sys.argv) > 1:
             # cli usage => exit cmd loop
             stop = True
             print()
+
         return stop
 
     def update_path(self):

--- a/dev_shell/command_sets/dev_shell_commands.py
+++ b/dev_shell/command_sets/dev_shell_commands.py
@@ -15,9 +15,16 @@ def run_linters():
         'flake8',
         '--exclude=.git,__pycache__,.tox,.venv',
         '--max-line-length=119',
+        exit_on_error=True
     )
-    verbose_check_call('isort', '--check-only', '.')
-    verbose_check_call('flynt', '--fail-on-change', '--line_length=119', 'dev_shell')
+    verbose_check_call(
+        'isort', '--check-only', '.',
+        exit_on_error=True
+    )
+    verbose_check_call(
+        'flynt', '--fail-on-change', '--line_length=119', 'dev_shell',
+        exit_on_error=True
+    )
 
 
 @cmd2.with_default_category('dev-shell commands')
@@ -26,7 +33,7 @@ class DevShellCommandSet(DevShellBaseCommandSet):
         """
         Run dev-shell tests via pytest
         """
-        verbose_check_call('pytest', *statement.arg_list)
+        verbose_check_call('pytest', *statement.arg_list, exit_on_error=True)
 
     def do_linting(self, statement: cmd2.Statement):
         """
@@ -56,7 +63,7 @@ class DevShellCommandSet(DevShellBaseCommandSet):
         Publish "dev-shell" to PyPi
         """
         # Don't publish if test failed or code linting wrong:
-        verbose_check_call('pytest', '-x')
+        verbose_check_call('pytest', '-x', exit_on_error=True)
         run_linters()
 
         poetry_publish(

--- a/dev_shell/utils/subprocess_utils.py
+++ b/dev_shell/utils/subprocess_utils.py
@@ -3,9 +3,10 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
-from dev_shell.utils.colorful import blue, bright_yellow, cyan, green
+from dev_shell.utils.colorful import blue, bright_yellow, cyan, green, print_error
 
 
 def argv2str(argv):
@@ -70,6 +71,7 @@ def verbose_check_call(
         verbose=True,
         cwd=None,
         extra_env=None,
+        exit_on_error=False,
         **kwargs):
     """ 'verbose' version of subprocess.check_call() """
 
@@ -82,13 +84,20 @@ def verbose_check_call(
     if extra_env:
         env.update(extra_env)
 
-    subprocess.check_call(
-        popenargs,
-        universal_newlines=True,
-        env=env,
-        cwd=cwd,
-        **kwargs
-    )
+    try:
+        return subprocess.check_call(
+            popenargs,
+            universal_newlines=True,
+            env=env,
+            cwd=cwd,
+            **kwargs
+        )
+    except subprocess.CalledProcessError as err:
+        if exit_on_error:
+            if verbose:
+                print_error(f'Process "{popenargs[0]}" finished with exit code {err.returncode!r}')
+            sys.exit(err.returncode)
+        raise
 
 
 def verbose_check_output(*popenargs, verbose=True, cwd=None, extra_env=None, **kwargs):


### PR DESCRIPTION
e.g.: A failed pytest run should exit the cmd2 app with >0 return code.
Otherwise it's not useable in CI pipelines ;)