### PR TITLE
Better "run as CLI" implementation

### DIFF
--- a/dev_shell/base_cmd2_app.py
+++ b/dev_shell/base_cmd2_app.py
@@ -59,12 +59,7 @@ class DevShellBaseApp(cmd2.Cmd):
             # Pass the sys.exit() code
             # See also: https://github.com/python-cmd2/cmd2/pull/1076
             self.exit_code = exit_code
-            stop = False
-
-        if len(sys.argv) > 1:
-            # cli usage => exit cmd loop
             stop = True
-            print()
 
         return stop
 
@@ -76,3 +71,18 @@ class DevShellBaseApp(cmd2.Cmd):
         env_path = os.environ.get('PATH', '')
         if not env_path.startswith(bin_path):
             os.environ['PATH'] = bin_path + os.pathsep + env_path
+
+
+def run_cmd2_app(app: cmd2.Cmd) -> None:
+    """
+    Run a cmd2 App as CLI or shell.
+    Handle exit code return value, too.
+    """
+    if len(sys.argv) > 1:
+        # CLI usage => run only one command and then exit
+        app.onecmd_plus_hooks(line=argv2str(sys.argv[1:]))
+        exit_code = app.exit_code
+    else:
+        exit_code = app.cmdloop()
+
+    sys.exit(exit_code)

--- a/dev_shell/dev_shell_app.py
+++ b/dev_shell/dev_shell_app.py
@@ -1,7 +1,5 @@
-import sys
-
 import dev_shell
-from dev_shell.base_cmd2_app import DevShellBaseApp
+from dev_shell.base_cmd2_app import DevShellBaseApp, run_cmd2_app
 from dev_shell.command_sets.dev_shell_commands import DevShellCommandSet
 from dev_shell.config import DevShellConfig
 
@@ -39,5 +37,5 @@ def devshell_cmdloop():
     Entry point to start the "dev-shell" cmd2 app.
     Used in: [tool.poetry.scripts]
     """
-    c = DevShellApp(**get_devshell_app_kwargs())
-    sys.exit(c.cmdloop())
+    app = DevShellApp(**get_devshell_app_kwargs())
+    run_cmd2_app(app)  # Run a cmd2 App as CLI or shell


### PR DESCRIPTION
Add `run_cmd2_app()` helper for easier use. This will handle the `exit_code`, too.

Call `app.onecmd_plus_hooks()` for CLI mode, so we must not change the cmd2 app code.
But we still need the work-a-round for https://github.com/python-cmd2/cmd2/pull/1076