### PR TITLE
Bugfix calls outside the project directory...

### DIFF
--- a/dev_shell/config.py
+++ b/dev_shell/config.py
@@ -10,6 +10,7 @@ class DevShellConfig:
     # Set by post init from package_module:
     version: str = dataclasses.field(init=False)
     package_path: Path = dataclasses.field(init=False)
+    base_path: Path = dataclasses.field(init=False)
 
     def __post_init__(self):
         assert self.package_module, 'Package module must be set!'
@@ -23,3 +24,4 @@ class DevShellConfig:
 
         self.version = self.package_module.__version__
         self.package_path = Path(self.package_module.__file__).parent
+        self.base_path = self.package_path.parent

--- a/dev_shell/constants.py
+++ b/dev_shell/constants.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+
+BASE_PATH = Path(__file__).parent.parent.resolve()
+assert Path(BASE_PATH / 'dev_shell').is_dir(), f'Path wrong: {BASE_PATH}'
+
+
+if sys.platform == 'win32':  # wtf
+    BIN_NAME = 'Scripts'
+else:
+    BIN_NAME = 'bin'
+
+VENV_PATH = BASE_PATH / '.venv'
+
+BIN_PATH = VENV_PATH / BIN_NAME
+assert BIN_PATH.is_dir()

--- a/dev_shell/tests/constants.py
+++ b/dev_shell/tests/constants.py
@@ -1,0 +1,17 @@
+import sys
+
+from dev_shell.constants import BIN_PATH
+
+
+if sys.platform == 'win32':
+    VENV_PYTHON = BIN_PATH / 'python.exe'
+    VENV_PIP = BIN_PATH / 'pip.exe'
+    VENV_POETRY = BIN_PATH / 'poetry.exe'
+    VENV_DEVSHELL = BIN_PATH / 'devshell'  # No ".exe" !
+else:
+    VENV_PYTHON = BIN_PATH / 'python'
+    VENV_PIP = BIN_PATH / 'pip'
+    VENV_POETRY = BIN_PATH / 'poetry'
+    VENV_DEVSHELL = BIN_PATH / 'devshell'
+
+DEVSHELL_CALL = f'{VENV_PYTHON} {VENV_DEVSHELL}'  # e.g.: ".venv/bin/python .venv/bin/devshell"

--- a/dev_shell/tests/test_bootstrap.py
+++ b/dev_shell/tests/test_bootstrap.py
@@ -12,23 +12,20 @@ from unittest import TestCase, mock
 import devshell
 from dev_shell.constants import VENV_PATH
 from dev_shell.tests.constants import DEVSHELL_CALL, VENV_DEVSHELL, VENV_PIP, VENV_POETRY, VENV_PYTHON
-from dev_shell.tests.utils import SubprocessMock
+from dev_shell.tests.utils import call_mocked_subprocess
 from dev_shell.utils.assertion import assert_is_dir, assert_is_file
 
 
 def call_devsetup_main(*args, catch_sys_exit=False):
     out = io.StringIO()
     err = io.StringIO()
-    with redirect_stdout(out), redirect_stderr(err), \
-            SubprocessMock('check_call') as check_call_mock:
-
-        try:
-            devshell.main(args)
-        except SystemExit:
-            if not catch_sys_exit:
-                raise
-
-    check_calls = check_call_mock.check_calls
+    with redirect_stdout(out), redirect_stderr(err):
+        check_calls = call_mocked_subprocess(
+            'check_call',
+            devshell.main,
+            args,
+            catch_sys_exit=catch_sys_exit
+        )
 
     if sys.platform == 'win32':
         # FIXME: e.g.: https://github.com/jedie/dev-shell/runs/2272270967

--- a/dev_shell/tests/test_bootstrap.py
+++ b/dev_shell/tests/test_bootstrap.py
@@ -10,24 +10,10 @@ from pathlib import Path
 from unittest import TestCase, mock
 
 import devshell
+from dev_shell.constants import VENV_PATH
+from dev_shell.tests.constants import DEVSHELL_CALL, VENV_DEVSHELL, VENV_PIP, VENV_POETRY, VENV_PYTHON
 from dev_shell.tests.utils import SubprocessMock
 from dev_shell.utils.assertion import assert_is_dir, assert_is_file
-
-
-if sys.platform == 'win32':
-    BIN_PATH = Path('.venv', 'Scripts')
-    VENV_PYTHON = BIN_PATH / 'python3.exe'
-    VENV_PIP = BIN_PATH / 'pip.exe'
-    VENV_POETRY = BIN_PATH / 'poetry.exe'
-    VENV_DEVSHELL = BIN_PATH / 'devshell'  # No ".exe" !
-else:
-    BIN_PATH = Path('.venv', 'bin')
-    VENV_PYTHON = BIN_PATH / 'python3'
-    VENV_PIP = BIN_PATH / 'pip'
-    VENV_POETRY = BIN_PATH / 'poetry'
-    VENV_DEVSHELL = BIN_PATH / 'devshell'
-
-DEVSHELL_CALL = f'{VENV_PYTHON} {VENV_DEVSHELL}'  # e.g.: ".venv/bin/python3 .venv/bin/devshell"
 
 
 def call_devsetup_main(*args, catch_sys_exit=False):
@@ -105,7 +91,7 @@ class BootstrapTestCase(TestCase):
             f'{VENV_POETRY} install',
             DEVSHELL_CALL
         ]
-        create_mock.assert_called_once_with(env_dir=Path('.venv'))
+        create_mock.assert_called_once_with(env_dir=VENV_PATH)
 
     def test_help(self):
         check_calls, stdout, stderr = call_devsetup_main(

--- a/dev_shell/tests/test_linting.py
+++ b/dev_shell/tests/test_linting.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
 
 from dev_shell.command_sets.dev_shell_commands import run_linters
+from dev_shell.constants import BASE_PATH
 
 
 class LintingTestCase(TestCase):
     def test_linting(self):
-        run_linters()
+        run_linters(cwd=BASE_PATH)

--- a/dev_shell/tests/test_subprocess_utils.py
+++ b/dev_shell/tests/test_subprocess_utils.py
@@ -1,0 +1,147 @@
+import os
+import platform
+from pathlib import Path
+from unittest import TestCase
+
+from dev_shell.constants import BASE_PATH, BIN_PATH, VENV_PATH
+from dev_shell.tests.constants import VENV_PYTHON
+from dev_shell.tests.utils import RedirectStdOutErr, SubprocessMock
+from dev_shell.utils.subprocess_utils import _print_info, prepare_popenargs, verbose_check_call, verbose_check_output
+
+
+class SubprocessUtilsTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.origin_cwd = Path.cwd()
+        os.chdir(BASE_PATH)
+
+    def tearDown(self):
+        super().tearDown()
+        os.chdir(self.origin_cwd)
+
+    def test_prepare_popenargs(self):
+        popenargs, cwd = prepare_popenargs(
+            popenargs=[BASE_PATH / 'devshell.py'],
+            cwd=None
+        )
+        assert popenargs == [str(BASE_PATH / 'devshell.py')]
+        assert cwd == BASE_PATH
+
+        popenargs, cwd = prepare_popenargs(
+            popenargs=['python', '--version'],
+            cwd=None
+        )
+        assert popenargs == [str(VENV_PYTHON), '--version']
+        assert cwd == BASE_PATH
+
+        popenargs, cwd = prepare_popenargs(
+            popenargs=['python', '--version'],
+            cwd=Path.cwd()
+        )
+        assert popenargs == [str(VENV_PYTHON), '--version']
+        assert cwd == BASE_PATH
+
+        popenargs, cwd = prepare_popenargs(
+            popenargs=['python', '--version'],
+            cwd=BIN_PATH
+        )
+        assert popenargs == [str(VENV_PYTHON), '--version']
+        assert cwd == BIN_PATH
+
+        popenargs, cwd = prepare_popenargs(
+            popenargs=['python', '--version'],
+            cwd=BIN_PATH.parent  # .../dev-shell/.venv/
+        )
+        assert popenargs == [str(VENV_PYTHON), '--version']
+        assert cwd == BIN_PATH.parent
+
+        popenargs, cwd = prepare_popenargs(
+            popenargs=['python', '--version'],
+            cwd=Path(__file__).parent
+        )
+        assert popenargs == [str(VENV_PYTHON), '--version']
+        assert cwd == Path(__file__).parent
+
+        with self.assertRaises(NotADirectoryError) as cm:
+            prepare_popenargs(
+                popenargs=['does not exists'],
+                cwd='/does/not/exists/'
+            )
+        assert cm.exception.args[0] == 'Directory does not exists: "/does/not/exists"'
+
+        with self.assertRaises(FileNotFoundError) as cm:
+            prepare_popenargs(popenargs=['does not exists'])
+        assert cm.exception.args[0] == 'Command "does not exists" not found in PATH!'
+
+    def test_print_info(self):
+        def call_print_info(*args, **kwargs):
+            with RedirectStdOutErr() as redirector:
+                _print_info(*args, **kwargs)
+
+            output = redirector.get_output(remove_ansi=True)
+            output = output.strip()
+            output = output.lstrip('\n_')
+            return output
+
+        output = call_print_info(
+            popenargs=['python', '--version'],
+            cwd=Path.cwd(),
+            kwargs={}
+        )
+        assert output == '+ ./python --version'
+
+        output = call_print_info(
+            popenargs=['foo', '--bar'],
+            cwd=Path('/somewhere/'),
+            kwargs={'shell': False}
+        )
+        assert output == '+ /somewhere$ foo --bar (kwargs: shell=False)'
+
+        output = call_print_info(
+            popenargs=[str(VENV_PYTHON), '--version'],
+            cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/,
+            kwargs={}
+        )
+        assert output == '+ .venv$ bin/python --version'
+
+    def test_verbose_check_call(self):
+        with RedirectStdOutErr() as redirector, SubprocessMock('check_call') as check_call_mock:
+            verbose_check_call(
+                str(VENV_PYTHON), '--version',
+                cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/,
+                shell=False
+            )
+        assert check_call_mock.check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
+
+        output = redirector.get_output(remove_ansi=True)
+        output = output.strip()
+        output = output.lstrip('\n_')
+        assert output == '+ .venv$ bin/python --version (kwargs: shell=False)'
+
+    def test_check_output_mocked(self):
+        with RedirectStdOutErr() as redirector, SubprocessMock('check_output') as check_call_mock:
+            verbose_check_output(
+                VENV_PYTHON, '--version',
+                cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/
+                shell=False
+            )
+        assert check_call_mock.check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
+
+        output = redirector.get_output(remove_ansi=True)
+        output = output.strip()
+        output = output.lstrip('\n_')
+        assert output == '+ .venv$ bin/python --version (kwargs: shell=False)'
+
+    def test_check_output(self):
+        with RedirectStdOutErr() as redirector:
+            output = verbose_check_output(
+                VENV_PYTHON, '--version',
+                cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/
+                shell=False
+            )
+            assert output == f'Python {platform.python_version()}\n'
+
+        output = redirector.get_output(remove_ansi=True)
+        output = output.strip()
+        output = output.lstrip('\n_')
+        assert output == '+ .venv$ bin/python --version (kwargs: shell=False)'

--- a/dev_shell/tests/test_subprocess_utils.py
+++ b/dev_shell/tests/test_subprocess_utils.py
@@ -5,7 +5,7 @@ from unittest import TestCase
 
 from dev_shell.constants import BASE_PATH, BIN_PATH, VENV_PATH
 from dev_shell.tests.constants import VENV_PYTHON
-from dev_shell.tests.utils import RedirectStdOutErr, SubprocessMock
+from dev_shell.tests.utils import RedirectStdOutErr, call_mocked_subprocess
 from dev_shell.utils.subprocess_utils import _print_info, prepare_popenargs, verbose_check_call, verbose_check_output
 
 
@@ -105,13 +105,15 @@ class SubprocessUtilsTestCase(TestCase):
         assert output == '+ .venv$ bin/python --version'
 
     def test_verbose_check_call(self):
-        with RedirectStdOutErr() as redirector, SubprocessMock('check_call') as check_call_mock:
-            verbose_check_call(
+        with RedirectStdOutErr() as redirector:
+            check_calls = call_mocked_subprocess(
+                'check_call',
+                verbose_check_call,
                 str(VENV_PYTHON), '--version',
                 cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/,
                 shell=False
             )
-        assert check_call_mock.check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
+            assert check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
 
         output = redirector.get_output(remove_ansi=True)
         output = output.strip()
@@ -119,13 +121,15 @@ class SubprocessUtilsTestCase(TestCase):
         assert output == '+ .venv$ bin/python --version (kwargs: shell=False)'
 
     def test_check_output_mocked(self):
-        with RedirectStdOutErr() as redirector, SubprocessMock('check_output') as check_call_mock:
-            verbose_check_output(
+        with RedirectStdOutErr() as redirector:
+            check_calls = call_mocked_subprocess(
+                'check_output',
+                verbose_check_output,
                 VENV_PYTHON, '--version',
                 cwd=Path(BIN_PATH / '..').resolve(),  # .../dev-shell/.venv/
                 shell=False
             )
-        assert check_call_mock.check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
+            assert check_calls == [f'{VENV_PATH}$ {VENV_PYTHON} --version']
 
         output = redirector.get_output(remove_ansi=True)
         output = output.strip()

--- a/dev_shell/tests/utils.py
+++ b/dev_shell/tests/utils.py
@@ -1,4 +1,8 @@
+import io
+from contextlib import redirect_stderr, redirect_stdout
 from unittest import mock
+
+from cmd2.ansi import strip_style
 
 from dev_shell.utils.subprocess_utils import argv2str
 
@@ -32,3 +36,30 @@ class SubprocessMock:
                 self.check_calls.append(command_str)
         finally:
             self.mock.__exit__()
+
+
+class RedirectStdOutErr:
+    """
+    Buffer stdout + stderr with optional strip_style() call
+    """
+    def __init__(self):
+        self._buffer = io.StringIO()
+        self._output = None
+
+    def __enter__(self):
+        self._stdout_redirect = redirect_stdout(self._buffer).__enter__()
+        self._stderr_redirect = redirect_stderr(self._buffer).__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            self._output = self._buffer.getvalue()
+        finally:
+            self._stdout_redirect.__exit__(exc_type, exc_val, exc_tb)
+            self._stderr_redirect.__exit__(exc_type, exc_val, exc_tb)
+
+    def get_output(self, remove_ansi=False):
+        output = self._output
+        if remove_ansi:
+            output = strip_style(output)
+        return output

--- a/dev_shell/utils/assertion.py
+++ b/dev_shell/utils/assertion.py
@@ -7,7 +7,9 @@ def assert_is_dir(path):
     """
     if not isinstance(path, Path):
         path = Path(path)
-    assert path.is_dir(), f'Directory does not exists: {path}'
+
+    if not path.is_dir():
+        raise NotADirectoryError(f'Directory does not exists: "{path}"')
 
 
 def assert_is_file(path):
@@ -16,5 +18,8 @@ def assert_is_file(path):
     """
     if not isinstance(path, Path):
         path = Path(path)
+
     assert_is_dir(path.parent)
-    assert path.is_file(), f'File does not exists: {path}'
+
+    if not path.is_file():
+        raise FileNotFoundError(f'File does not exists: "{path}"')

--- a/dev_shell/utils/subprocess_utils.py
+++ b/dev_shell/utils/subprocess_utils.py
@@ -6,18 +6,69 @@ import subprocess
 import sys
 from pathlib import Path
 
-from dev_shell.utils.colorful import blue, bright_yellow, cyan, green, print_error
+from dev_shell.utils.assertion import assert_is_dir
+from dev_shell.utils.colorful import blue, bright_blue, bright_white, bright_yellow, cyan, green, print_error
 
 
 def argv2str(argv):
     """
     >>> argv2str(['foo', '--bar=123'])
     'foo --bar=123'
+    >>> argv2str([Path('/foo/bar'), '--foo'])
+    '/foo/bar --foo'
     """
-    return ' '.join(a if re.match(r'^[-0-9a-zA-Z_.=]+$', a) else shlex.quote(a) for a in argv)
+    items = []
+    for item in argv:
+        if isinstance(item, Path):
+            item = str(item)
+
+        if re.match(r'^[-0-9a-zA-Z_.=]+$', item):
+            items.append(item)
+        else:
+            items.append(shlex.quote(item))
+
+    return ' '.join(items)
 
 
-def _print_info(popenargs, kwargs):
+def make_relative_path(path, relative_to):
+    """
+    Makes {path} relative to {relative_to}, e.g.:
+    >>> str(make_relative_path(Path('/one/two/three'), relative_to=Path('/one')))
+    'two/three'
+
+    >>> str(make_relative_path(Path('/foo/bar/.venv/bin/python'), relative_to=Path('/foo/bar/.venv')))
+    'bin/python'
+
+    Will resolve the paths, e.g.:
+    >>> str(make_relative_path(Path('../one/two/three'), relative_to=Path('../one')))
+    'two/three'
+
+    Does nothing if {path} doesn't start with {relative_to}, e.g:
+    >>> str(make_relative_path(Path('/one/two'), relative_to=Path('/other/path')))
+    '/one/two'
+    """
+    assert isinstance(path, Path)
+    assert isinstance(relative_to, Path)
+
+    path = path.absolute()
+    relative_to = relative_to.absolute()
+
+    try:
+        is_relative_to = path.is_relative_to(relative_to)
+    except AttributeError:  # is_relative_to() is new in Python 3.9
+        try:
+            path = path.relative_to(relative_to)
+        except ValueError:
+            # {path} doesn't start with {relative_to} -> do nothing
+            pass
+    else:
+        if is_relative_to:
+            path = path.relative_to(relative_to)
+
+    return path
+
+
+def _print_info(popenargs, *, cwd, kwargs):
     print()
     print('_' * 100)
 
@@ -29,19 +80,27 @@ def _print_info(popenargs, kwargs):
         command = command_str
         args = ''
 
-    command_path = Path(command)
+    command_path = make_relative_path(Path(command), relative_to=cwd)
+    cwd = make_relative_path(cwd, relative_to=Path.cwd())
+
     command_name = command_path.name
     command_dir = command_path.parent
 
     info = ''
-    if command_dir:
+
+    if cwd.absolute() != Path.cwd().absolute():
+        info = f'{bright_blue(str(cwd))}{bright_white("$")} '
+
+    if command_dir and command_dir != Path.cwd():
         info += green(f'{command_dir}{os.sep}')
+
     if command_name:
         info += bright_yellow(command_name)
+
     if args:
         info += f' {blue(args)}'
 
-    msg = f'Call: {info}'
+    msg = f'+ {info}'
 
     verbose_kwargs = ', '.join(f'{k}={v!r}' for k, v in sorted(kwargs.items()))
     if verbose_kwargs:
@@ -50,20 +109,30 @@ def _print_info(popenargs, kwargs):
     print(f'{msg}\n', flush=True)
 
 
-def prepare_popenargs(popenargs):
+def prepare_popenargs(popenargs, cwd=None):
     popenargs = [str(part) for part in popenargs]  # e.g.: Path() instance -> str
 
-    command = popenargs[0]
-    if not Path(command).is_file():
-        # Search in PATH for this command that doesn't point to a existing file:
-        command = shutil.which(command)
+    if cwd is None:
+        cwd = Path.cwd()
+    else:
+        assert_is_dir(cwd)
+
+    command_path = Path(popenargs[0])
+
+    if not command_path.is_file():
+        # Lookup in current venv bin path first:
+        bin_path = str(Path(sys.executable).parent.absolute())
+        command = shutil.which(command_path, path=bin_path)
         if not command:
-            raise FileNotFoundError(f'Command "{popenargs[0]}" not found in PATH!')
+            # Search in PATH for this command that doesn't point to a existing file:
+            command = shutil.which(command_path)
+            if not command:
+                raise FileNotFoundError(f'Command "{popenargs[0]}" not found in PATH!')
 
         # Replace command name with full path:
         popenargs[0] = command
 
-    return popenargs
+    return popenargs, cwd
 
 
 def verbose_check_call(
@@ -75,10 +144,10 @@ def verbose_check_call(
         **kwargs):
     """ 'verbose' version of subprocess.check_call() """
 
-    popenargs = prepare_popenargs(popenargs)
+    popenargs, cwd = prepare_popenargs(popenargs, cwd=cwd)
 
     if verbose:
-        _print_info(popenargs, kwargs)
+        _print_info(popenargs, cwd=cwd, kwargs=kwargs)
 
     env = os.environ.copy()
     if extra_env:
@@ -103,10 +172,10 @@ def verbose_check_call(
 def verbose_check_output(*popenargs, verbose=True, cwd=None, extra_env=None, **kwargs):
     """ 'verbose' version of subprocess.check_output() """
 
-    popenargs = prepare_popenargs(popenargs)
+    popenargs, cwd = prepare_popenargs(popenargs, cwd=cwd)
 
     if verbose:
-        _print_info(popenargs, kwargs)
+        _print_info(popenargs, cwd=cwd, kwargs=kwargs)
 
     env = os.environ.copy()
     if extra_env:

--- a/devshell.py
+++ b/devshell.py
@@ -38,13 +38,14 @@ else:
     BIN_NAME = 'bin'
     FILE_EXT = ''
 
-VENV_PATH = Path('.venv')
+BASE_PATH = Path(__file__).parent
+VENV_PATH = BASE_PATH / '.venv'
 BIN_PATH = VENV_PATH / BIN_NAME
-PYTHON_PATH = BIN_PATH / f'python3{FILE_EXT}'
+PYTHON_PATH = BIN_PATH / f'python{FILE_EXT}'
 PIP_PATH = BIN_PATH / f'pip{FILE_EXT}'
 POETRY_PATH = BIN_PATH / f'poetry{FILE_EXT}'
 
-DEP_LOCK_PATH = Path('poetry.lock')
+DEP_LOCK_PATH = BASE_PATH / 'poetry.lock'
 DEP_HASH_PATH = VENV_PATH / '.dep_hash'
 
 # script file defined in pyproject.toml as [tool.poetry.scripts]


### PR DESCRIPTION
* Use absolute path in `../devshell.py`
* Run internal commands with `cwd=self.config.base_path`
* Better verbose subprocess verbose output

There is no "python3.exe" in .venv on Windows 10 with python.org installation, only a "python.exe"

On Linux we have both. So it seem to be save to use "python.exe" and "python" instead of
"python3.exe" and "python3" everywhere.