### PR TITLE
Bugfix error on Windows:

### DIFF
--- a/dev_shell/utils/subprocess_utils.py
+++ b/dev_shell/utils/subprocess_utils.py
@@ -122,10 +122,10 @@ def prepare_popenargs(popenargs, cwd=None):
     if not command_path.is_file():
         # Lookup in current venv bin path first:
         bin_path = str(Path(sys.executable).parent.absolute())
-        command = shutil.which(command_path, path=bin_path)
+        command = shutil.which(str(command_path), path=bin_path)
         if not command:
             # Search in PATH for this command that doesn't point to a existing file:
-            command = shutil.which(command_path)
+            command = shutil.which(str(command_path))
             if not command:
                 raise FileNotFoundError(f'Command "{popenargs[0]}" not found in PATH!')
 


### PR DESCRIPTION
```
  File "C:\Users\sysop\PycharmProjects\dev-shell\dev_shell\utils\subprocess_utils.py", line 125, in prepare_popenargs
    command = shutil.which(command_path, path=bin_path)
  File "C:\Users\sysop\AppData\Local\Programs\Python\Python39\lib\shutil.py", line 1441, in which
    if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
  File "C:\Users\sysop\AppData\Local\Programs\Python\Python39\lib\shutil.py", line 1441, in <genexpr>
    if any(cmd.lower().endswith(ext.lower()) for ext in pathext):
AttributeError: 'WindowsPath' object has no attribute 'lower'
EXCEPTION of type 'AttributeError' occurred with message: ''WindowsPath' object has no attribute 'lower''
```